### PR TITLE
depreciate supercharged_dart

### DIFF
--- a/lib/src/codecs/string/decoder.dart
+++ b/lib/src/codecs/string/decoder.dart
@@ -104,7 +104,9 @@ class RecurrenceRuleFromStringDecoder
               if (match == null) {
                 throw FormatException('Cannot parse date or date-time');
               }
-              return _UntilOrCount(until: match.copyWith(isUtc: true));
+              return _UntilOrCount(
+                until: DateTimeRrule(match).copyWith(isUtc: true),
+              );
             },
           );
           break;

--- a/lib/src/codecs/string/ical.dart
+++ b/lib/src/codecs/string/ical.dart
@@ -90,7 +90,9 @@ class _ICalPropertyToStringEncoder extends Converter<ICalProperty, String> {
       output.writeICalParameter(entry.key, entry.value);
     }
 
-    output..write(':')..write(input.value);
+    output
+      ..write(':')
+      ..write(input.value);
     return output.toString();
   }
 }

--- a/lib/src/codecs/text/l10n/l10n.dart
+++ b/lib/src/codecs/text/l10n/l10n.dart
@@ -85,13 +85,19 @@ abstract class RruleL10n {
         return '${items.first}$two${items[1]}';
       default:
         final output = StringBuffer(items.first);
-        output..write(start)..write(items[1]);
+        output
+          ..write(start)
+          ..write(items[1]);
 
         for (final entry in items.sublist(2, items.length - 1)) {
-          output..write(middle)..write(entry);
+          output
+            ..write(middle)
+            ..write(entry);
         }
 
-        output..write(end)..write(items.last);
+        output
+          ..write(end)
+          ..write(items.last);
         return output.toString();
     }
   }

--- a/lib/src/iteration/date_set.dart
+++ b/lib/src/iteration/date_set.dart
@@ -1,6 +1,6 @@
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
-import 'package:supercharged_dart/supercharged_dart.dart';
+import 'package:time/time.dart';
 
 import '../frequency.dart';
 import '../recurrence_rule.dart';
@@ -13,7 +13,7 @@ class DateSet {
     required this.start,
     required this.end,
     required this.firstDayOfYear,
-  })   : assert(start >= 0),
+  })  : assert(start >= 0),
         assert(start <= end),
         assert(firstDayOfYear.isValidRruleDate);
 
@@ -34,7 +34,7 @@ class DateSet {
       isIncluded: List.generate(length, (i) => start <= i && i < actualEnd),
       start: start,
       end: actualEnd,
-      firstDayOfYear: base.copyWith(month: 1, day: 1),
+      firstDayOfYear: DateTimeRrule(base).copyWith(month: 1, day: 1),
     );
   }
 
@@ -53,7 +53,7 @@ class DateSet {
   DateTime? operator [](int index) {
     if (!isIncluded[index]) return null;
 
-    return firstDayOfYear + index.days;
+    return firstDayOfYear.add(index.days);
   }
 
   Iterable<DateTime> get includedDates =>
@@ -100,7 +100,7 @@ DateSet _buildWeeklyDateSet(DateTime base) {
   var current = base;
   for (final _ in 0.until(DateTime.daysPerWeek)) {
     i++;
-    current += 1.days;
+    current = current.add(1.days);
     if (current.weekday == DateTime.monday) break;
   }
   return DateSet.create(base: base, addExtraWeek: true, start: start, end: i);

--- a/lib/src/iteration/date_set_filtering.dart
+++ b/lib/src/iteration/date_set_filtering.dart
@@ -1,4 +1,4 @@
-import 'package:supercharged_dart/supercharged_dart.dart';
+import 'package:time/time.dart';
 
 import '../frequency.dart';
 import '../recurrence_rule.dart';
@@ -15,7 +15,7 @@ import 'date_set.dart';
 bool removeFilteredDates(RecurrenceRule rrule, DateSet dateSet) {
   var isFiltered = false;
   for (final i in dateSet.start.until(dateSet.end)) {
-    final date = dateSet.firstDayOfYear + i.days;
+    final date = dateSet.firstDayOfYear.add(i.days);
     final isCurrentFiltered = _isFiltered(rrule, date);
 
     dateSet.isIncluded[i] = !isCurrentFiltered;

--- a/lib/src/iteration/frequency_interval.dart
+++ b/lib/src/iteration/frequency_interval.dart
@@ -1,4 +1,4 @@
-import 'package:supercharged_dart/supercharged_dart.dart';
+import 'package:time/time.dart';
 
 import '../frequency.dart';
 import '../recurrence_rule.dart';
@@ -52,10 +52,10 @@ extension _FrequencyIntervalCalculation on DateTime {
 
   DateTime _addWeeks(int weeks) {
     final surplusDays = (weekday - DateTime.monday) % DateTime.daysPerWeek;
-    return this + weeks.weeks - surplusDays.days;
+    return add(weeks.weeks).subtract(surplusDays.days);
   }
 
-  DateTime _addDays(int days) => this + days.days;
+  DateTime _addDays(int days) => add(days.days);
 
   DateTime _addHours(int hours, bool wereDatesFiltered, Set<int> byHours) {
     var newValue = this;
@@ -64,12 +64,12 @@ extension _FrequencyIntervalCalculation on DateTime {
       final timeToLastHour = Duration.hoursPerDay - 1 - newValue.hour;
       final hoursToLastIterationOfDay =
           (timeToLastHour / hours).floor() * hours;
-      newValue += hoursToLastIterationOfDay.hours;
+      newValue.add(hoursToLastIterationOfDay.hours);
     }
 
     // ignore: literal_only_boolean_expressions
     while (true) {
-      newValue += hours.hours;
+      newValue = newValue.add(hours.hours);
 
       if (byHours.isEmpty || byHours.contains(newValue.hour)) break;
     }
@@ -91,7 +91,7 @@ extension _FrequencyIntervalCalculation on DateTime {
           newValue.minute;
       final minutesToLastIterationOfDay =
           (timeToLastMinute / minutes).floor() * minutes;
-      newValue += minutesToLastIterationOfDay.minutes;
+      newValue = newValue.add(minutesToLastIterationOfDay.minutes);
     }
 
     // ignore: literal_only_boolean_expressions
@@ -101,7 +101,7 @@ extension _FrequencyIntervalCalculation on DateTime {
       if (hours > 0) {
         newValue = newValue._addHours(hours, wereDatesFiltered, byHours);
       }
-      newValue += minutesWithoutHours.minutes;
+      newValue = newValue.add(minutesWithoutHours.minutes);
 
       if ((byHours.isEmpty || byHours.contains(newValue.hour)) &&
           (byMinutes.isEmpty || byMinutes.contains(newValue.minute))) {

--- a/lib/src/iteration/iteration.dart
+++ b/lib/src/iteration/iteration.dart
@@ -1,5 +1,3 @@
-import 'package:supercharged_dart/supercharged_dart.dart';
-
 import '../by_week_day_entry.dart';
 import '../codecs/string/ical.dart';
 import '../frequency.dart';
@@ -46,7 +44,7 @@ Iterable<DateTime> getRecurrenceRuleInstances(
           .where((dt) => start <= dt);
     } else {
       results = dateSet.includedDates.expand((date) {
-        return timeSet.map((time) => date + time);
+        return timeSet.map((time) => date.add(time));
       });
     }
 

--- a/lib/src/iteration/set_positions_list.dart
+++ b/lib/src/iteration/set_positions_list.dart
@@ -1,4 +1,4 @@
-import 'package:supercharged_dart/supercharged_dart.dart';
+import 'package:time/time.dart';
 
 import '../recurrence_rule.dart';
 import '../utils.dart';
@@ -31,7 +31,7 @@ Iterable<DateTime> buildSetPositionsList(
     }
 
     final dateIndex = dateIndices[datePosition % dateIndices.length];
-    final date = dateSet.firstDayOfYear + dateIndex.days;
+    final date = dateSet.firstDayOfYear.add(dateIndex.days);
     yield date + timeList[timePosition];
   }
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,8 +1,5 @@
 import 'dart:math' as math;
-
-import 'package:supercharged_dart/supercharged_dart.dart';
-
-import 'utils/week.dart';
+import 'package:time/time.dart';
 
 export 'utils/week.dart';
 
@@ -108,19 +105,17 @@ extension DateTimeRrule on DateTime {
   DateTime plusYears(int years) => plusYearsAndMonths(years: years);
   DateTime plusMonths(int months) => plusYearsAndMonths(months: months);
 
-  DateTime get firstDayOfYear => atStartOfDay.copyWith(month: 1, day: 1);
-  DateTime get lastDayOfYear => atStartOfDay.copyWith(month: 12, day: 31);
-  DateTime get firstDayOfMonth => atStartOfDay.copyWith(day: 1);
-  DateTime get lastDayOfMonth => plusMonths(1).firstDayOfMonth - 1.days;
-  int get daysInMonth {
-    final february = isLeapYear ? 29 : 28;
-    return [31, february, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1];
-  }
+  DateTime get firstDayOfYear =>
+      DateTimeRrule(atStartOfDay).copyWith(month: 1, day: 1);
+  DateTime get lastDayOfYear =>
+      DateTimeRrule(atStartOfDay).copyWith(month: 12, day: 31);
+  DateTime get firstDayOfMonth => DateTimeRrule(atStartOfDay).copyWith(day: 1);
+  DateTime get lastDayOfMonth => plusMonths(1).firstDayOfMonth.subtract(1.days);
 
   DateTime nextOrSame(int dayOfWeek) {
     assert(dayOfWeek.isValidRruleDayOfWeek);
 
-    return this + ((dayOfWeek - weekday) % DateTime.daysPerWeek).days;
+    return add(((dayOfWeek - weekday) % DateTime.daysPerWeek).days);
   }
 }
 
@@ -149,8 +144,43 @@ extension NullableDurationRrule on Duration? {
       this == null || (0.days <= this! && this! <= 1.days);
 }
 
-extension IntRrule on int {
-  Duration get weeks => (this * 7).days;
+extension IntRange on int {
+  // Copied from supercharged_dart
+
+  /// Creates an [Iterable<int>] that contains all values from current integer
+  /// until (including) the value [n].
+  ///
+  /// Example:
+  /// ```dart
+  /// 0.rangeTo(5); // [0, 1, 2, 3, 4, 5]
+  /// 3.rangeTo(1); // [3, 2, 1]
+  /// ```
+  Iterable<int> rangeTo(int n) {
+    final count = (n - this).abs() + 1;
+    final direction = (n - this).sign;
+    var i = this - direction;
+    return Iterable.generate(count, (index) {
+      return i += direction;
+    });
+  }
+
+  /// Creates an [Iterable<int>] that contains all values from current integer
+  /// until (excluding) the value [n].
+  ///
+  /// Example:
+  /// ```dart
+  /// 0.until(5); // [0, 1, 2, 3, 4]
+  /// 3.until(1); // [3, 2]
+  /// ```
+  Iterable<int> until(int n) {
+    if (this < n) {
+      return rangeTo(n - 1);
+    } else if (this > n) {
+      return rangeTo(n + 1);
+    } else {
+      return Iterable.empty();
+    }
+  }
 }
 
 extension NullableIntRrule on int? {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   collection: ^1.15.0
   intl: ^0.17.0
   meta: ^1.3.0
-  supercharged_dart: ^2.0.0
+  time: ^2.1.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4

--- a/test/rrule_ical_test.dart
+++ b/test/rrule_ical_test.dart
@@ -1,6 +1,6 @@
 import 'package:meta/meta.dart';
 import 'package:rrule/rrule.dart';
-import 'package:supercharged_dart/supercharged_dart.dart';
+import 'package:rrule/src/utils.dart';
 import 'package:test/test.dart';
 
 import 'utils.dart' as utils;
@@ -738,7 +738,7 @@ void main() {
       Duration(hours: 9, minutes: 45),
       Duration(hours: 10, minutes: 0),
       Duration(hours: 10, minutes: 15),
-    ].map((t) => DateTime.utc(1997, 9, 2) + t),
+    ].map((t) => DateTime.utc(1997, 9, 2).add(t)),
   );
   testRrule(
     'Every hour and a half for 4 occurrences',
@@ -755,7 +755,7 @@ void main() {
       Duration(hours: 10, minutes: 30),
       Duration(hours: 12, minutes: 0),
       Duration(hours: 13, minutes: 30),
-    ].map((t) => DateTime.utc(1997, 9, 2) + t),
+    ].map((t) => DateTime.utc(1997, 9, 2).add(t)),
   );
   group('Every 20 minutes from 9:00 AM to 4:40 PM every day', () {
     final expected = [2, 3].expand((d) {


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->


<!-- Add the breaking label (PR: BREAKING) if applicable. -->

<!-- Please summarize your changes: -->
Since `supercharged_dart` stops development, and we don't need all of its arguments anyway, I've cleaned up the package with these methods:

- Replace with native arguments
- Replace with smaller, maintained packages (`time`)
- Copy only what we need from `supercharged_dart` and put it in (`until` and `rangeTo`, both stems from `Iterable.generate`)
>- These seems to be quite useful, and IMHO should be part of `collection`. But that's for another time.

Otherwise nothing changed.

All tests still passes.