### PR TITLE
Conversion support to use RecurrenceRule with native code or export it (JSON)

### DIFF
--- a/lib/src/by_week_day_entry.dart
+++ b/lib/src/by_week_day_entry.dart
@@ -41,6 +41,20 @@ class ByWeekDayEntry implements Comparable<ByWeekDayEntry> {
 
   @override
   String toString() => ByWeekDayEntryStringCodec().encode(this);
+
+  factory ByWeekDayEntry.fromJson(Map<String, int?>? json) {
+    if (json == null) {
+      throw ArgumentError('The json object is null');
+    }
+    return ByWeekDayEntry(json['day']!, json['occurrence']);
+  }
+
+  Map<String, dynamic> toJson() {
+    final data = <String, dynamic>{};
+    data['day'] = day;
+    data['occurrence'] = occurrence;
+    return data;
+  }
 }
 
 extension ByWeekDayEntryIterable on Iterable<ByWeekDayEntry> {

--- a/lib/src/by_week_day_entry.dart
+++ b/lib/src/by_week_day_entry.dart
@@ -53,7 +53,7 @@ class ByWeekDayEntry implements Comparable<ByWeekDayEntry> {
     final data = <String, dynamic>{};
     data['day'] = day;
     data['occurrence'] = occurrence;
-    return data;
+    return data..removeWhere((key, dynamic value) => value == null);
   }
 }
 

--- a/lib/src/codecs/string/decoder.dart
+++ b/lib/src/codecs/string/decoder.dart
@@ -82,7 +82,7 @@ class RecurrenceRuleFromStringDecoder
             name,
             value,
             oldValue: frequency,
-            parse: () => _frequencyFromString(value),
+            parse: () => frequencyFromString(value),
           );
           break;
         case recurRulePartUntil:
@@ -359,7 +359,28 @@ class RecurrenceRuleFromStringDecoder
   }
 }
 
-Frequency? _frequencyFromString(String input) => recurFreqValues[input];
+Frequency? intToFrequency(int? input) {
+  if (input == null) return null;
+  switch (input) {
+    case 6:
+      return Frequency.secondly;
+    case 5:
+      return Frequency.minutely;
+    case 4:
+      return Frequency.hourly;
+    case 3:
+      return Frequency.daily;
+    case 2:
+      return Frequency.weekly;
+    case 1:
+      return Frequency.monthly;
+    case 0:
+      return Frequency.yearly;
+  }
+}
+
+Frequency? frequencyFromString(String input) => recurFreqValues[input];
+
 int? _weekDayFromString(String day) => recurWeekDayValues[day];
 
 /// Helper class to reuse the logic of

--- a/lib/src/codecs/string/encoder.dart
+++ b/lib/src/codecs/string/encoder.dart
@@ -74,6 +74,27 @@ String? _frequencyToString(Frequency? input) {
   return recurFreqValues.entries.singleWhere((e) => e.value == input).key;
 }
 
+int? frequencyToInt(Frequency? input) {
+  if (input == null) return null;
+  final recurFrequency = input.toString();
+  switch (recurFrequency) {
+    case recurFreqSecondly:
+      return 6;
+    case recurFreqMinutely:
+      return 5;
+    case recurFreqHourly:
+      return 4;
+    case recurFreqDaily:
+      return 3;
+    case recurFreqWeekly:
+      return 2;
+    case recurFreqMonthly:
+      return 1;
+    case recurFreqYearly:
+      return 0;
+  }
+}
+
 String? _weekDayToString(int? dayOfWeek) {
   assert(dayOfWeek.isValidRruleDayOfWeek);
 

--- a/lib/src/recurrence_rule.dart
+++ b/lib/src/recurrence_rule.dart
@@ -380,7 +380,6 @@ class RecurrenceRule {
     if (json == null) {
       throw ArgumentError('The json object is null');
     }
-
     Set<int> _listToSet(List<dynamic>? list) {
       if (list == null) {
         return {};
@@ -396,7 +395,9 @@ class RecurrenceRule {
       } else {
         final finalList = list.cast<Map<String, int>>();
         final entries = <ByWeekDayEntry>{};
-        finalList.map((e) => entries.add(ByWeekDayEntry.fromJson(e)));
+        for (final element in finalList) {
+          entries.add(ByWeekDayEntry.fromJson(element));
+        }
         return entries;
       }
     }
@@ -426,7 +427,7 @@ class RecurrenceRule {
   // TODO(GoldenSoju): Set has to be changed to List in order for method channel to accept it. Check if that is the best way to solve it.
   // TODO(GoldenSoju): Until has to be changed to int/long. Check how to solve this the best way.
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'recurrenceFrequency': frequencyToInt(frequency),
+        'frequency': frequencyToInt(frequency),
         'until': until?.millisecondsSinceEpoch,
         'count': count,
         'interval': interval,
@@ -441,8 +442,23 @@ class RecurrenceRule {
         'byMonths': byMonths.toList(),
         'bySetPositions': bySetPositions.toList(),
         'weekStart': actualWeekStart,
-        'shouldCacheResults': shouldCacheResults,
-      };
+      }..removeWhere((key, dynamic value) {
+          if (value is int?) {
+            if (value == null) {
+              return true;
+            } else {
+              return false;
+            }
+          } else if (value is List?) {
+            if (value!.isEmpty) {
+              return true;
+            } else {
+              return false;
+            }
+          } else {
+            return false;
+          }
+        });
 }
 
 /// Validates the `seconds` rule.

--- a/lib/src/recurrence_rule.dart
+++ b/lib/src/recurrence_rule.dart
@@ -375,6 +375,74 @@ class RecurrenceRule {
     }
     return true;
   }
+
+  factory RecurrenceRule.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      throw ArgumentError('The json object is null');
+    }
+
+    Set<int> _listToSet(List<dynamic>? list) {
+      if (list == null) {
+        return {};
+      } else {
+        final finalList = list.cast<int>();
+        return finalList.toSet();
+      }
+    }
+
+    Set<ByWeekDayEntry> _listToWeekdayEntrySet(List<dynamic>? list) {
+      if (list == null) {
+        return {};
+      } else {
+        final finalList = list.cast<Map<String, int>>();
+        final entries = <ByWeekDayEntry>{};
+        finalList.map((e) => entries.add(ByWeekDayEntry.fromJson(e)));
+        return entries;
+      }
+    }
+
+    final _until = json['until'] == null
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(json['until'] as int,
+            isUtc: true);
+    return RecurrenceRule(
+      frequency: intToFrequency(json['frequency'] as int?) ?? Frequency.yearly,
+      until: _until,
+      count: json['count'] as int?,
+      interval: json['interval'] as int?,
+      bySeconds: _listToSet(json['bySeconds'] as List<dynamic>?),
+      byMinutes: _listToSet(json['byMinutes'] as List<dynamic>?),
+      byHours: _listToSet(json['byHours'] as List<dynamic>?),
+      byWeekDays: _listToWeekdayEntrySet(json['byWeekDays'] as List<dynamic>?),
+      byMonthDays: _listToSet(json['byMonthDays'] as List<dynamic>?),
+      byYearDays: _listToSet(json['byYearDays'] as List<dynamic>?),
+      byWeeks: _listToSet(json['byWeeks'] as List<dynamic>?),
+      byMonths: _listToSet(json['byMonths'] as List<dynamic>?),
+      bySetPositions: _listToSet(json['bySetPositions'] as List<dynamic>?),
+      weekStart: json['weekStart'] as int? ?? DateTime.monday,
+    );
+  }
+
+  // TODO(GoldenSoju): Set has to be changed to List in order for method channel to accept it. Check if that is the best way to solve it.
+  // TODO(GoldenSoju): Until has to be changed to int/long. Check how to solve this the best way.
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'recurrenceFrequency': frequencyToInt(frequency),
+        'until': until?.millisecondsSinceEpoch,
+        'count': count,
+        'interval': interval,
+        'bySeconds': bySeconds.toList(),
+        'byMinutes': byMinutes.toList(),
+        'byHours': byHours.toList(),
+        'byWeekDays':
+            byWeekDays.map((weekDayEntry) => weekDayEntry.toJson()).toList(),
+        'byMonthDays': byMonthDays.toList(),
+        'byYearDays': byYearDays.toList(),
+        'byWeeks': byWeeks.toList(),
+        'byMonths': byMonths.toList(),
+        'bySetPositions': bySetPositions.toList(),
+        'weekStart': actualWeekStart,
+        'shouldCacheResults': shouldCacheResults,
+      };
 }
 
 /// Validates the `seconds` rule.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,10 +9,10 @@ environment:
 dependencies:
   collection: ^1.15.0
   intl: ^0.17.0
-  meta: ^1.3.0
+  meta: ^1.7.0
   time: ^2.1.0
 
 dev_dependencies:
   flutter_lints: ^1.0.4
-  test: ^1.16.8
+  test: ^1.20.1
   # test_coverage: ^0.5.0

--- a/test/json_compatibility_test.dart
+++ b/test/json_compatibility_test.dart
@@ -1,0 +1,270 @@
+import 'package:rrule/rrule.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('rrule_json', () {
+    test('Rrule(daily) to JSON', () {
+      final rrule = RecurrenceRule(
+        frequency: Frequency.daily,
+        count: 2,
+        interval: 1,
+      ).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 3,
+        'count': 2,
+        'interval': 1,
+        'weekStart': 1
+      });
+    });
+
+    test('Rrule(weekly) to JSON', () {
+      final rrule = RecurrenceRule(
+        frequency: Frequency.weekly,
+        count: 2,
+        interval: 1,
+      ).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 2,
+        'count': 2,
+        'interval': 1,
+        'weekStart': 1
+      });
+    });
+
+    test('Rrule(weekly byWeekDays) to JSON', () {
+      final rrule = RecurrenceRule(
+          frequency: Frequency.weekly,
+          count: 2,
+          interval: 1,
+          byWeekDays: {
+            ByWeekDayEntry(DateTime.monday),
+            ByWeekDayEntry(DateTime.thursday)
+          }).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 2,
+        'count': 2,
+        'interval': 1,
+        'byWeekDays': [
+          {'day': 1},
+          {'day': 4}
+        ],
+        'weekStart': 1
+      });
+    });
+
+    test('Rrule(monthly by day) to JSON', () {
+      final rrule = RecurrenceRule(
+          frequency: Frequency.monthly,
+          count: 2,
+          interval: 1,
+          byMonthDays: {2, 12, 31}).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 1,
+        'count': 2,
+        'interval': 1,
+        'byMonthDays': [2, 12, 31],
+        'weekStart': 1
+      });
+    });
+
+    test('Rrule(monthly byWeekDays) to JSON', () {
+      final rrule = RecurrenceRule(
+          frequency: Frequency.monthly,
+          count: 2,
+          interval: 1,
+          byWeekDays: {ByWeekDayEntry(DateTime.monday, 2)}).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 1,
+        'count': 2,
+        'interval': 1,
+        'byWeekDays': [
+          {'day': 1, 'occurrence': 2}
+        ],
+        'weekStart': 1
+      });
+    });
+
+    test('Rrule(yearly) to JSON', () {
+      final rrule = RecurrenceRule(
+          frequency: Frequency.yearly,
+          count: 2,
+          interval: 1,
+          byMonths: {3, 5, 9},
+          byMonthDays: {2, 12, 31}).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 0,
+        'count': 2,
+        'interval': 1,
+        'byMonths': [3, 5, 9],
+        'byMonthDays': [2, 12, 31],
+        'weekStart': 1
+      });
+    });
+
+    test('Rrule(yearly byWeekDays) to JSON', () {
+      final rrule = RecurrenceRule(
+          frequency: Frequency.yearly,
+          count: 2,
+          interval: 1,
+          byMonths: {
+            3,
+            5,
+            9
+          },
+          byWeekDays: {
+            ByWeekDayEntry(DateTime.wednesday, 1),
+            ByWeekDayEntry(DateTime.wednesday, 3)
+          }).toJson();
+
+      expect(rrule, <String, dynamic>{
+        'frequency': 0,
+        'count': 2,
+        'interval': 1,
+        'byMonths': [3, 5, 9],
+        'byWeekDays': [
+          {'day': 3, 'occurrence': 1},
+          {'day': 3, 'occurrence': 3}
+        ],
+        'weekStart': 1
+      });
+    });
+  });
+
+  group('json_rrule', () {
+    test('JSON(daily) to Rrule', () {
+      final json = RecurrenceRule.fromJson(
+          <String, dynamic>{'frequency': 3, 'count': 2, 'interval': 1});
+
+      expect(
+          json,
+          RecurrenceRule(
+              frequency: Frequency.daily, count: 2, interval: 1, weekStart: 1));
+    });
+
+    test('JSON(weekly) to Rrule', () {
+      final json = RecurrenceRule.fromJson(<String, dynamic>{
+        'frequency': 2,
+        'count': 2,
+        'interval': 1,
+        'weekStart': 1
+      });
+
+      expect(json,
+          RecurrenceRule(frequency: Frequency.weekly, count: 2, interval: 1));
+    });
+
+    test('JSON(weekly byWeekDays) to Rrule', () {
+      final json = RecurrenceRule.fromJson(<String, dynamic>{
+        'frequency': 2,
+        'count': 2,
+        'interval': 1,
+        'byWeekDays': [
+          {'day': 1},
+          {'day': 4}
+        ],
+      });
+
+      expect(
+          json,
+          RecurrenceRule(
+              frequency: Frequency.weekly,
+              count: 2,
+              interval: 1,
+              byWeekDays: {
+                ByWeekDayEntry(DateTime.monday),
+                ByWeekDayEntry(DateTime.thursday)
+              },
+              weekStart: 1));
+    });
+
+    test('JSON(monthly by day) to Rrule', () {
+      final json = RecurrenceRule.fromJson(<String, dynamic>{
+        'frequency': 1,
+        'count': 2,
+        'interval': 1,
+        'byMonthDays': [2, 12, 31],
+      });
+
+      expect(
+          json,
+          RecurrenceRule(
+              frequency: Frequency.monthly,
+              count: 2,
+              interval: 1,
+              byMonthDays: {2, 12, 31},
+              weekStart: 1));
+    });
+  });
+
+  test('JSON(monthly byWeekDays) to Rrule', () {
+    final json = RecurrenceRule.fromJson(<String, dynamic>{
+      'frequency': 1,
+      'count': 2,
+      'interval': 1,
+      'byWeekDays': [
+        {'day': 1, 'occurrence': 2}
+      ],
+    });
+
+    expect(
+        json,
+        RecurrenceRule(
+            frequency: Frequency.monthly,
+            count: 2,
+            interval: 1,
+            byWeekDays: {ByWeekDayEntry(DateTime.monday, 2)},
+            weekStart: 1));
+  });
+
+  test('JSON(yearly) to Rrule', () {
+    final json = RecurrenceRule.fromJson(<String, dynamic>{
+      'frequency': 0,
+      'count': 2,
+      'interval': 1,
+      'byMonths': [3, 5, 9],
+      'byMonthDays': [2, 12, 31],
+    });
+
+    expect(
+        json,
+        RecurrenceRule(
+            frequency: Frequency.yearly,
+            count: 2,
+            interval: 1,
+            byMonths: {3, 5, 9},
+            byMonthDays: {2, 12, 31},
+            weekStart: 1));
+  });
+
+  test('JSON(yearly byWeekDays) to Rrule', () {
+    final json = RecurrenceRule.fromJson(<String, dynamic>{
+      'frequency': 0,
+      'count': 2,
+      'interval': 1,
+      'byMonths': [3, 5, 9],
+      'byWeekDays': [
+        {'day': 3, 'occurrence': 1},
+        {'day': 3, 'occurrence': 3}
+      ],
+    });
+
+    expect(
+        json,
+        RecurrenceRule(
+            frequency: Frequency.yearly,
+            count: 2,
+            interval: 1,
+            byMonths: {3, 5, 9},
+            byWeekDays: {
+              ByWeekDayEntry(DateTime.wednesday, 1),
+              ByWeekDayEntry(DateTime.wednesday, 3)
+            },
+            weekStart: 1));
+  });
+}


### PR DESCRIPTION
###  Reason
To be able to use RecurrenceRules with native code (e.g. Method Channel) or to export it (e.g. to server), minimal support for to and from JSON conversion is needed.

### Changes
<!-- Please summarize your changes: -->
- Added `fromJson`/`toJson` functions for `RecurrenceRule` and `ByWeekDayEntry`
- Added tests for `fromJson`/`toJson` (`json_compatibility_test.dart`)
- Added util functions `intToFrequency`/`frequencyToInt`
- Make `frequencyFromString` public
- Updated dependencies in pubspec.yaml
   - meta: ^1.3.0 -> ^1.7.0
   - test: ^1.16.8 -> ^1.20.1

### Checklist
<!-- Please check if your PR fulfills the following requirements: -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
