### PR TITLE
Fix non-latin date parsing for UNTIL

### DIFF
--- a/lib/src/codecs/string/encoder.dart
+++ b/lib/src/codecs/string/encoder.dart
@@ -85,6 +85,40 @@ String weekDayToString(int dayOfWeek) {
       .key;
 }
 
+extension _RecurrenceRuleDateString on DateTime {
+  /// Pattern corresponding to the `DATE-TIME` rule specified in
+  /// [RFC 5545 Section 3.3.5: Date-Time](https://tools.ietf.org/html/rfc5545#section-3.3.5).
+  // It is based on DateTime.toIso8601String excluding 6 digit years
+  String toRecurrenceRulePattern() {
+    assert(
+      0 <= year && year <= iCalMaxYear,
+      'Years with more than four digits are not supported.',
+    );
+
+    final y = _fourDigits(year);
+    final m = _twoDigits(month);
+    final d = _twoDigits(day);
+    final h = _twoDigits(hour);
+    final min = _twoDigits(minute);
+    final sec = _twoDigits(second);
+    return '$y$m${d}T$h$min$sec';
+  }
+
+  static String _twoDigits(int n) {
+    if (n >= 10) return '$n';
+    return '0$n';
+  }
+
+  static String _fourDigits(int n) {
+    final absN = n.abs();
+    final sign = n < 0 ? '-' : '';
+    if (absN >= 1000) return '$n';
+    if (absN >= 100) return '${sign}0$absN';
+    if (absN >= 10) return '${sign}00$absN';
+    return '${sign}000$absN';
+  }
+}
+
 extension _RecurrenceRuleEncoderStringBuffer on StringBuffer {
   void writeDateTime(
     DateTime input,
@@ -97,7 +131,7 @@ extension _RecurrenceRuleEncoderStringBuffer on StringBuffer {
       'See https://tools.ietf.org/html/rfc5545#section-3.3.4 for more '
       'information.',
     );
-    write(iCalDateTimePattern.format(input));
+    write(input.toRecurrenceRulePattern());
     if (options.isTimeUtc) write('Z');
   }
 

--- a/lib/src/codecs/string/ical.dart
+++ b/lib/src/codecs/string/ical.dart
@@ -1,21 +1,7 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
-
-/// Pattern corresponding to the `DATE` rule specified in
-/// [RFC 5545 Section 3.3.4: Date](https://tools.ietf.org/html/rfc5545#section-3.3.4).
-final iCalDatePattern = DateFormat('yyyyMMdd');
-
-/// Pattern corresponding to the `TIME` rule specified in
-/// [RFC 5545 Section 3.3.12: Time](https://tools.ietf.org/html/rfc5545#section-3.3.12).
-final iCalTimePattern = DateFormat('HHmmss');
-
-/// Pattern corresponding to the `DATE-TIME` rule specified in
-/// [RFC 5545 Section 3.3.5: Date-Time](https://tools.ietf.org/html/rfc5545#section-3.3.5).
-final iCalDateTimePattern =
-    DateFormat("${iCalDatePattern.pattern}'T'${iCalTimePattern.pattern}");
 
 /// Maximum year number supported by iCalendar.
 const iCalMaxYear = 9999;

--- a/test/rrule_ical_test.dart
+++ b/test/rrule_ical_test.dart
@@ -18,6 +18,7 @@ void main() {
     required DateTime start,
     required Iterable<DateTime> expected,
     bool isInfinite = false,
+    bool testNonLatin = false,
   }) {
     utils.testRrule(
       description,
@@ -28,8 +29,28 @@ void main() {
       expected: expected,
       isInfinite: isInfinite,
       l10n: () => l10n,
+      testNonLatin: testNonLatin,
     );
   }
+
+  // Non-latin tests
+  testRrule(
+    'Daily until December 24, 1997 - Non-Latin',
+    string: 'RRULE:FREQ=DAILY;UNTIL=19971224T000000Z',
+    text: 'Daily, until Wednesday, December 24, 1997 12:00:00 AM',
+    rrule: RecurrenceRule(
+      frequency: Frequency.daily,
+      until: DateTime.utc(1997, 12, 24),
+    ),
+    start: DateTime.utc(1997, 9, 2, 9, 0, 0),
+    expected: [
+      ...2.until(31).map((d) => DateTime.utc(1997, 9, d, 9, 0, 0)),
+      ...1.until(32).map((d) => DateTime.utc(1997, 10, d, 9, 0, 0)),
+      ...1.until(31).map((d) => DateTime.utc(1997, 11, d, 9, 0, 0)),
+      ...1.until(24).map((d) => DateTime.utc(1997, 12, d, 9, 0, 0)),
+    ],
+    testNonLatin: true,
+  );
 
   // All examples taken from https://tools.ietf.org/html/rfc5545#section-3.8.5.3.
   // - Some RRULE-strings had some fields reordered to match the production rule

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,3 +1,5 @@
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:rrule/rrule.dart';
 import 'package:test/test.dart';
@@ -17,8 +19,23 @@ void testRrule(
   required Iterable<DateTime> expected,
   bool isInfinite = false,
   required RruleL10n Function() l10n,
+  bool testNonLatin = false,
 }) {
   group(description, () {
+    setUp(() async {
+      if (testNonLatin) {
+        Intl.defaultLocale = 'ar';
+        await initializeDateFormatting();
+      }
+    });
+
+    tearDown(() async {
+      if (testNonLatin) {
+        Intl.defaultLocale = 'en';
+        await initializeDateFormatting();
+      }
+    });
+
     testStringCodec(
       'StringCodec',
       codec: const RecurrenceRuleStringCodec(


### PR DESCRIPTION
Closes: #59

* Instead of using intl.DateFormat.format to generate rrule.toString create a custom date time string for UNTIL based on modified code from DateTime.toIso8601String
* Added a test for non-latin Arabic locale