### PR TITLE
feat(iteration): add shortcut for iterating over dates

### DIFF
--- a/lib/src/iteration/iteration.dart
+++ b/lib/src/iteration/iteration.dart
@@ -31,6 +31,14 @@ Iterable<DateTime> getRecurrenceRuleInstances(
   var count = rrule.count;
 
   var currentStart = start;
+
+  if (count == null && after != null) {
+    /// Shortcut for not calculating unnecessary recurrences.
+    final skippableDifference = after.difference(start);
+
+    currentStart = currentStart.add(skippableDifference);
+  }
+
   var timeSet = makeTimeSet(rrule, start.timeOfDay);
 
   // ignore: literal_only_boolean_expressions

--- a/lib/src/iteration/iteration.dart
+++ b/lib/src/iteration/iteration.dart
@@ -33,10 +33,8 @@ Iterable<DateTime> getRecurrenceRuleInstances(
   var currentStart = start;
 
   if (count == null && after != null) {
-    /// Shortcut for not calculating unnecessary recurrences.
-    final skippableDifference = after.difference(start);
-
-    currentStart = currentStart.add(skippableDifference);
+    // Shortcut for not calculating unnecessary recurrences.
+    currentStart = after;
   }
 
   var timeSet = makeTimeSet(rrule, start.timeOfDay);


### PR DESCRIPTION
<!-- Please summarize your changes and add screenshots if applicable: -->
I couldn't stop thinking about what is going to happen if the calendar package I'm currently working on is going to still be used in the far future.

I was wondering, how to solve the issue of finding the recurrences of an event I create as infinitely recurring from next Friday, if it is never stopped and 900 or so years have passed. (900 just as in "many")

Given the following code:
```dart
const testRrule = 'RRULE:FREQ=DAILY;INTERVAL=2';

final recurrencesFarFromNow = RecurrenceRule.fromString(testRrule)
    .getInstances(
      start: DateTime.utc(2000),
      after: DateTime.utc(2900),
      before: DateTime.utc(2901),
    )
    .toList();
```

It would iterate over 900 years of recurrence, in total over 160.000 `DateTime`s that get compared and dropped, because they are not in range yet.

My code change is quite small, but improves this behavior significantly.
It allows to "look back" at past recurrences chunk-wise, instead of calculating and caching them. This was impossible before, because the calculations were just too inefficient to always skip all of these years for every new chunk to load.

All tests are passing, I would still request you, @JonasWanke to think with me about a case where this small calculation would fail. Maybe I also missed something.