### PR TITLE
fix(iteration): prevent IntegerDivisionByZeroException with SETPOS

### DIFF
--- a/lib/src/iteration/set_positions_list.dart
+++ b/lib/src/iteration/set_positions_list.dart
@@ -30,6 +30,8 @@ Iterable<DateTime> buildSetPositionsList(
       if (dateSet.isIncluded[k]) dateIndices.add(k);
     }
 
+    if (dateIndices.isEmpty) continue;
+
     final dateIndex = dateIndices[datePosition % dateIndices.length];
     final date = dateSet.firstDayOfYear.add(dateIndex.days);
     yield date + timeList[timePosition];

--- a/test/recurrence_rule_test.dart
+++ b/test/recurrence_rule_test.dart
@@ -186,6 +186,32 @@ void main() {
       expect(instances.length, 4);
     },
   );
+  test('#44: prevent IntegerDivisionByZeroException with SETPOS', () {
+    final rrule = RecurrenceRule(
+      frequency: Frequency.monthly,
+      interval: 1,
+      byWeekDays: [
+        ByWeekDayEntry(DateTime.wednesday),
+        ByWeekDayEntry(DateTime.saturday),
+      ],
+      byMonths: const [10, 12],
+      bySetPositions: const [2, 4],
+      until: DateTime.utc(2023, 01, 06, 14, 15),
+    );
+    final start = DateTime.utc(2022);
+
+    final instances = rrule.getInstances(start: start).take(5);
+
+    expect(
+      instances,
+      equals([
+        DateTime.utc(2022, 10, 05),
+        DateTime.utc(2022, 10, 12),
+        DateTime.utc(2022, 12, 07),
+        DateTime.utc(2022, 12, 14),
+      ]),
+    );
+  });
   test(
     '#46: Start DateTime with microseconds should not skip first instance',
     () {


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #44 

<!-- Please summarize your changes and add screenshots if applicable: -->
The problem is, if you go by month, it iterates over every day of every month, starting with January. In the provided example, no day of year in January (1-31) matches any date in the dateset, therefore `dateIndices` is empty and it throws a `IntegerDivisionByZeroException` when using `dateIndices.length` on the right hand side of the modulo operator in `set_positions_list.dart`.
https://github.com/JonasWanke/rrule/blob/f557fe9e72821c0543b1bf8f56fe5f50d531b07d/lib/src/iteration/set_positions_list.dart#L33

This PR fixes the problem by just moving on.