### PR TITLE
fix(iteration): bySetPositions index calculation

### DIFF
--- a/lib/src/iteration/set_positions_list.dart
+++ b/lib/src/iteration/set_positions_list.dart
@@ -30,6 +30,12 @@ Iterable<DateTime> buildSetPositionsList(
       if (dateSet.isIncluded[k]) dateIndices.add(k);
     }
 
+    if (dateIndices.isEmpty ||
+        datePosition >= dateIndices.length ||
+        -datePosition > dateIndices.length) {
+      continue;
+    }
+
     final dateIndex = dateIndices[datePosition % dateIndices.length];
     final date = dateSet.firstDayOfYear.add(dateIndex.days);
     yield date + timeList[timePosition];

--- a/test/recurrence_rule_test.dart
+++ b/test/recurrence_rule_test.dart
@@ -261,4 +261,27 @@ void main() {
     final instances = rrule.getInstances(start: start);
     expect(instances, isNotEmpty);
   });
+  test('#68: bySetPositions is behaving correctly', () {
+    final rrule = RecurrenceRule(
+      frequency: Frequency.weekly,
+      byWeekDays: [
+        ByWeekDayEntry(DateTime.monday),
+        ByWeekDayEntry(DateTime.wednesday),
+      ],
+      bySetPositions: const [2, 3],
+    );
+    final start = DateTime.utc(2024, 02, 01);
+
+    final instances = rrule.getInstances(start: start).take(5);
+    expect(
+      instances,
+      equals([
+        DateTime.utc(2024, 02, 07),
+        DateTime.utc(2024, 02, 14),
+        DateTime.utc(2024, 02, 21),
+        DateTime.utc(2024, 02, 28),
+        DateTime.utc(2024, 03, 06),
+      ]),
+    );
+  });
 }


### PR DESCRIPTION
<!-- Please enter the corresponding issue ID: -->
Closes: #68 

<!-- Please summarize your changes and add screenshots if applicable: -->
`dateIndex` is currently implemented so that edge cases, where it should "ignore" a SETPOS, lead to incorrect calculations.

I'm open for improvements, maybe I made the implementation of this check more complicated than it has to be.
It's late in Germany, so maybe I see a better way tomorrow. But this is the solution I found.

It includes the fix from #67, but not the test, so I would like them both to be merged. I will take care of rebasing if necessary.